### PR TITLE
refactor: standardize API response with pagination

### DIFF
--- a/server/src/modules/merchant/interfaces/IGroupRepository.ts
+++ b/server/src/modules/merchant/interfaces/IGroupRepository.ts
@@ -3,7 +3,7 @@
 import {
   AddMerchantToRegistryRequest,
   CreateGroupRequest,
-  GroupCreationResult,
+  CreateGroupResponse,
   GroupMember,
   GroupSummary,
   GroupWithMembers,
@@ -29,7 +29,7 @@ export interface IGroupRepository {
     groupData: CreateGroupRequest,
     members: AddMerchantToRegistryRequest[],
     merchantSourceId?: number
-  ): Promise<GroupCreationResult>;
+  ): Promise<CreateGroupResponse>;
 
   /**
    * Update group
@@ -65,4 +65,9 @@ export interface IGroupRepository {
    * Check if group exists
    */
   groupExists(groupId: number): Promise<boolean>;
+
+  /**
+   * Get all groups count
+   */
+  getAllGroupsCount(params?: CommonParams): Promise<number>;
 }

--- a/server/src/modules/merchant/interfaces/IGroupService.ts
+++ b/server/src/modules/merchant/interfaces/IGroupService.ts
@@ -3,8 +3,8 @@
 import {
   AddMerchantToRegistryRequest,
   CreateGroupRequest,
-  GroupCreationResult,
-  GroupSummary,
+  CreateGroupResponse,
+  GetGroupsResponse,
   GroupWithMembers,
   UpdateGroupRequest,
 } from '@guesense-dash/shared';
@@ -18,7 +18,7 @@ export interface IGroupService {
   /**
    * Get all groups
    */
-  getAllGroups(params?: CommonParams): Promise<GroupSummary[]>;
+  getAllGroups(params?: CommonParams): Promise<GetGroupsResponse>;
 
   /**
    * Get group detail with members
@@ -57,5 +57,5 @@ export interface IGroupService {
     groupData: CreateGroupRequest,
     members: AddMerchantToRegistryRequest[],
     merchantSourceId?: number
-  ): Promise<GroupCreationResult>;
+  ): Promise<CreateGroupResponse>;
 }

--- a/server/src/modules/merchant/interfaces/IMerchantRepository.ts
+++ b/server/src/modules/merchant/interfaces/IMerchantRepository.ts
@@ -38,4 +38,9 @@ export interface IMerchantRepository {
    * Check if merchant is registered
    */
   isMerchantRegistered(merchantId: number): Promise<boolean>;
+
+  /**
+   * Get reigistered merchants count
+   */
+  getRegisteredMerchantsCount(params: CommonParams): Promise<number>;
 }

--- a/server/src/modules/merchant/interfaces/IMerchantService.ts
+++ b/server/src/modules/merchant/interfaces/IMerchantService.ts
@@ -2,9 +2,9 @@
 
 import {
   AddMerchantToRegistryRequest,
-  BulkAddResult,
+  AddMerchantToRegistryResponse,
+  GetMerchantsResponse,
   Merchant,
-  MerchantWithRegistry,
   UpdateMerchantRegistryRequest,
 } from '@guesense-dash/shared';
 import { CommonParams } from 'server/src/shared';
@@ -21,12 +21,12 @@ export interface IMerchantService {
   /**
    * Get list of (registered) merchants
    */
-  getRegisteredIndividualMerchants(params?: CommonParams): Promise<MerchantWithRegistry[]>;
+  getRegisteredIndividualMerchants(params?: CommonParams): Promise<GetMerchantsResponse>;
 
   /**
    * Add merchant to registry
    */
-  addMerchantToRegistry(params: AddMerchantToRegistryRequest[]): Promise<BulkAddResult>;
+  addMerchantToRegistry(params: AddMerchantToRegistryRequest[]): Promise<AddMerchantToRegistryResponse>;
 
   /**
    * Update merchant registry

--- a/shared/src/dto/index.ts
+++ b/shared/src/dto/index.ts
@@ -9,11 +9,13 @@ export type { LoginRequest, LoginResponse, ValidateSessionResponse } from './aut
 // Export merchant DTOs
 export type {
   AddMerchantToRegistryRequest,
-  BulkAddResult,
+  AddMerchantToRegistryResponse,
   CreateGroupRequest,
+  CreateGroupResponse,
   GetGroupsRequest,
+  GetGroupsResponse,
   GetMerchantsRequest,
-  GroupCreationResult,
+  GetMerchantsResponse,
   UpdateGroupRequest,
   UpdateMerchantRegistryRequest,
 } from './merchant.dto';

--- a/shared/src/dto/merchant.dto.ts
+++ b/shared/src/dto/merchant.dto.ts
@@ -1,12 +1,32 @@
 // shared/src/dto/merchant.dto.ts
 
+import { GroupSummary, MerchantWithRegistry } from '../types';
 import { PaginationRequest, SearchFilter, StatusFilter } from './common.dto';
 
 export interface GetMerchantsRequest extends PaginationRequest, StatusFilter, SearchFilter {}
 
+export interface GetMerchantsResponse {
+  merchants: MerchantWithRegistry[];
+  pagination: {
+    total: number;
+    totalPages: number;
+    currentPage: number;
+    hasNextPage: boolean;
+  };
+}
+
 export interface AddMerchantToRegistryRequest {
   merchant_id: number;
   merchant_code: string;
+}
+
+export interface AddMerchantToRegistryResponse {
+  successCount: number;
+  totalCount: number;
+  failed: Array<{
+    merchant_id: number;
+    error: string;
+  }>;
 }
 
 export interface UpdateMerchantRegistryRequest {
@@ -17,28 +37,22 @@ export interface UpdateMerchantRegistryRequest {
 
 export interface GetGroupsRequest extends PaginationRequest, SearchFilter, StatusFilter {}
 
+export interface GetGroupsResponse {
+  groups: GroupSummary[];
+  pagination: {
+    total: number;
+    totalPages: number;
+    currentPage: number;
+    hasNextPage: boolean;
+  };
+}
+
 export interface CreateGroupRequest {
   name: string;
   status?: number;
 }
 
-export interface UpdateGroupRequest {
-  id: number;
-  name?: string;
-  status?: number;
-  merchant_source_id?: number | null;
-}
-
-export interface BulkAddResult {
-  successCount: number;
-  totalCount: number;
-  failed: Array<{
-    merchant_id: number;
-    error: string;
-  }>;
-}
-
-export interface GroupCreationResult {
+export interface CreateGroupResponse {
   groupId: number;
   groupName: string;
   membersSuccessCount: number;
@@ -49,4 +63,11 @@ export interface GroupCreationResult {
   }>;
   sourceSet: boolean;
   sourceMerchantId?: number;
+}
+
+export interface UpdateGroupRequest {
+  id: number;
+  name?: string;
+  status?: number;
+  merchant_source_id?: number | null;
 }


### PR DESCRIPTION
- Rename DTOs to be more descriptive (e.g. BulkAddResult -> AddMerchantToRegistryResponse)
- Add pagination metadata to group and merchant list responses
- Add count methods to repositories to support pagination
- Update interfaces and implementations to use new response types
- Maintain consistent naming convention across DTOs